### PR TITLE
Allow a setting for a separate USB console

### DIFF
--- a/firmware/application/Makefile
+++ b/firmware/application/Makefile
@@ -21,7 +21,7 @@
 TARGET      = jumpstarter
 TARGET_ELF  = target/thumbv7em-none-eabihf/release/jumpstarter
 TARGET_DEBUG_ELF  = target/thumbv7em-none-eabihf/debug/jumpstarter
-VERSION     = 0.04
+VERSION     = 0.05
 
 METADATA_DATE = $(shell date -u +%Y-%m-%d)
 GIT_REF=$(shell git describe --always --abbrev=12 --dirty)

--- a/firmware/application/src/shell.rs
+++ b/firmware/application/src/shell.rs
@@ -38,7 +38,7 @@ pub const HELP: &str = "\r\n\
         power on|off        : power on or off the DUT\r\n\
         send string         : send string to the DUT\r\n\
         set r|a|b|c|d l|h|z : set RESET, CTL_A,B,C or D to low, high or high impedance\r\n\
-        set-config name|tags|storage value : set the config value in flash\r\n\
+        set-config name|tags|storage|usb_console value : set the config value in flash\r\n\
         status              : print status of the device\r\n\
         storage dut|host|off: connect storage to DUT, host or disconnect\r\n\
         version             : print version information\r\n\
@@ -296,6 +296,11 @@ where
             write!(response, "Set storage to {}", v).ok();
             config.write_config(&cfg).ok();
 
+        } else if k == "usb_console" {
+            let cfg = cfg.set_usb_console(v.as_bytes());
+            write!(response, "Set usb_console to {}", v).ok();
+            config.write_config(&cfg).ok();
+
         } else {
             usage = true;
         }
@@ -304,7 +309,7 @@ where
     }
 
     if usage {
-        write!(response, "usage: set-config name|tags|storage value").ok();
+        write!(response, "usage: set-config name|tags|storage|usb_storage value").ok();
     }
 }
 
@@ -320,6 +325,8 @@ where
         write_u8(response, &cfg.tags);
     } else if args == "storage" {
         write_u8(response, &cfg.storage);
+    } else if args == "usb_console" {
+        write_u8(response, &cfg.usb_console);
     } else if args == "" {
         write!(response, "name: ").ok();
         write_u8(response, &cfg.name);
@@ -327,8 +334,10 @@ where
         write_u8(response, &cfg.tags);
         write!(response, "\r\nstorage: ").ok();
         write_u8(response, &cfg.storage);
+        write!(response, "\r\nusb_console: ").ok();
+        write_u8(response, &cfg.usb_console);
     } else {
-        write!(response, "usage: get-config [name|tags|storage]").ok();
+        write!(response, "usage: get-config [name|tags|storage|usb_console]").ok();
     }
 }
 


### PR DESCRIPTION
The Orin AGX board provides access to the kernel and UEFI consoles via USB only today, not via the 40-pin header.

To allow jumpstarter accessing systems like these, we can enable the jumpstarter software to look-up for a separate usb console on the host.

i.e. with an Orin AGX board we could store:
set-config usb_console TOPOD83B461B-if01

this would in turn, tell the jumpstarter software on the host to look up for devices in /dev/serial/by-id/ that contain such string, like:

/dev/serial/by-id/usb-NVIDIA_Tegra_On-Platform_Operator_TOPOD83B461B-if01

and use that when a Console() is requested to the DUT